### PR TITLE
Add 'isAttackable' util

### DIFF
--- a/.agents/skills/battlechain/SKILL.md
+++ b/.agents/skills/battlechain/SKILL.md
@@ -151,10 +151,6 @@ Any contract over 24,576 bytes will fail to deploy.
 3. Use `--via-ir` for deeper optimization (slower compile, smaller output)
 4. Extract constants and large string literals into separate libraries
 
-### BattleChain does not support EIP-1559
-
-Every `forge script` and `cast send` call must include `--legacy`. Without it, transactions are rejected.
-
 ## Hardhat
 
 Coming soon...

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+ffi = true
 
 fs_permissions = [
     { access = "read", path = "./broadcast" },

--- a/src/BCQuery.sol
+++ b/src/BCQuery.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// aderyn-ignore-next-line(push-zero-opcode,unspecific-solidity-pragma)
+pragma solidity ^0.8.24;
+
+import { BCBase } from "./BCBase.sol";
+import { BCConfig } from "./BCConfig.sol";
+
+/// @notice Off-chain query helpers for BattleChain block explorer APIs.
+/// Requires FFI to be enabled (forge test --ffi / forge script --ffi).
+abstract contract BCQuery is BCBase {
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    string internal constant TESTNET_EXPLORER_API = "https://block-explorer-api.testnet.battlechain.com";
+    string internal constant MAINNET_EXPLORER_API = "https://block-explorer-api.battlechain.com";
+
+    // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    error BCQuery__ApiFailed(address contractAddress);
+    error BCQuery__UnsupportedChainForQuery(uint256 chainId);
+
+    string private constant _UNDER_ATTACK = "UNDER_ATTACK";
+    string private constant _PROMOTION_REQUESTED = "PROMOTION_REQUESTED";
+
+    // -------------------------------------------------------------------------
+    // Query functions
+    // -------------------------------------------------------------------------
+
+    /// @notice Checks if a contract is covered by an agreement that is in attackable mode
+    /// (state is UNDER_ATTACK or PROMOTION_REQUESTED).
+    /// Uses vm.ffi to call the block explorer API via curl.
+    /// Requires `--ffi` flag when running forge script/test.
+    // aderyn-ignore-next-line(internal-function-used-once)
+    function isAttackable(address contractAddress) internal returns (bool) {
+        string memory json = _queryAgreementByContract(contractAddress);
+
+        bool hasCoverage = vm.parseJsonBool(json, ".hasCoverage");
+        if (!hasCoverage) return false;
+
+        for (uint256 i;; ++i) {
+            string memory key = string.concat(".agreements[", vm.toString(i), "].state");
+            if (!vm.keyExistsJson(json, key)) break;
+
+            string memory state = vm.parseJsonString(json, key);
+            if (_isAttackableState(state)) return true;
+        }
+
+        return false;
+    }
+
+    /// @notice Returns true if the state string represents an attackable agreement.
+    function _isAttackableState(string memory state) private pure returns (bool) {
+        return
+            keccak256(bytes(state)) == keccak256(bytes(_UNDER_ATTACK))
+                || keccak256(bytes(state)) == keccak256(bytes(_PROMOTION_REQUESTED));
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /// @notice Queries the block explorer API for agreement data covering a contract.
+    /// Returns the raw JSON response string.
+    function _queryAgreementByContract(address contractAddress) internal virtual returns (string memory) {
+        string memory baseUrl = _explorerApiUrl();
+        string memory addrStr = vm.toString(contractAddress);
+        string memory url = string.concat(baseUrl, "/battlechain/agreement/by-contract/", addrStr);
+
+        string[] memory cmd = new string[](5);
+        cmd[0] = "curl";
+        cmd[1] = "-sf";
+        cmd[2] = "--max-time";
+        cmd[3] = "10";
+        cmd[4] = url;
+
+        bytes memory result = vm.ffi(cmd);
+        if (result.length == 0) {
+            revert BCQuery__ApiFailed(contractAddress);
+        }
+
+        return string(result);
+    }
+
+    /// @notice Returns the block explorer API base URL for the current chain.
+    function _explorerApiUrl() internal view virtual returns (string memory) {
+        if (block.chainid == BCConfig.TESTNET_CHAIN_ID) return TESTNET_EXPLORER_API;
+        if (block.chainid == BCConfig.MAINNET_CHAIN_ID) return MAINNET_EXPLORER_API;
+        revert BCQuery__UnsupportedChainForQuery(block.chainid);
+    }
+}

--- a/src/BCScript.sol
+++ b/src/BCScript.sol
@@ -4,10 +4,11 @@ pragma solidity ^0.8.24;
 
 import { BCDeploy } from "./BCDeploy.sol";
 import { BCSafeHarbor } from "./BCSafeHarbor.sol";
+import { BCQuery } from "./BCQuery.sol";
 import { Contact } from "./types/AgreementTypes.sol";
 
-/// @notice Single import combining BCDeploy and BCSafeHarbor with required protocol hooks.
-abstract contract BCScript is BCDeploy, BCSafeHarbor {
+/// @notice Single import combining BCDeploy, BCSafeHarbor, and BCQuery with required protocol hooks.
+abstract contract BCScript is BCDeploy, BCSafeHarbor, BCQuery {
     /// @notice The protocol name for the agreement.
     function _protocolName() internal pure virtual returns (string memory);
 

--- a/test/BCConfigTest.t.sol
+++ b/test/BCConfigTest.t.sol
@@ -32,12 +32,12 @@ contract BCConfigTest is Test {
 
     function test_testnet_registry() public {
         vm.chainId(627);
-        assertEq(BCConfig.registry(), 0x0A652e265336a0296816ac4D8400880E3e537c24);
+        assertEq(BCConfig.registry(), 0x0a652e265336a0296816aC4D8400880e3E537C24);
     }
 
     function test_testnet_agreementFactory() public {
         vm.chainId(627);
-        assertEq(BCConfig.agreementFactory(), 0x2BEe2970f10FDc2aeA28662Bb6f6a501278eBd46);
+        assertEq(BCConfig.agreementFactory(), 0x2Bee2970f10FDc2aeA28662BB6F6A501278Ebd46);
     }
 
     function test_testnet_attackRegistry() public {

--- a/test/BCQueryTest.t.sol
+++ b/test/BCQueryTest.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Test } from "forge-std/Test.sol";
+import { BCQuery } from "src/BCQuery.sol";
+import { MockBCDeployer, MockAgreementFactory, MockBCRegistry, MockAttackRegistry } from "test/mocks/MockBCInfra.sol";
+
+contract BCQueryHarness is BCQuery {
+    function configure(address registry, address factory, address attackRegistry, address deployer) external {
+        _setBcAddresses(registry, factory, attackRegistry, deployer);
+    }
+
+    /// @dev Override to use mock shell script instead of real curl.
+    function _queryAgreementByContract(address contractAddress) internal override returns (string memory) {
+        string[] memory cmd = new string[](3);
+        cmd[0] = "bash";
+        cmd[1] = "test/mocks/mock_api.sh";
+        cmd[2] = vm.toString(contractAddress);
+
+        bytes memory result = vm.ffi(cmd);
+        if (result.length == 0) {
+            revert BCQuery__ApiFailed(contractAddress);
+        }
+
+        return string(result);
+    }
+
+    function exposedIsAttackable(address contractAddress) external returns (bool) {
+        return isAttackable(contractAddress);
+    }
+}
+
+contract BCQueryTest is Test {
+    BCQueryHarness harness;
+
+    function setUp() public {
+        vm.chainId(627);
+
+        harness = new BCQueryHarness();
+
+        MockAgreementFactory factory = new MockAgreementFactory();
+        MockBCRegistry registry = new MockBCRegistry();
+        MockAttackRegistry attackRegistry = new MockAttackRegistry();
+        MockBCDeployer deployer = new MockBCDeployer();
+
+        harness.configure(address(registry), address(factory), address(attackRegistry), address(deployer));
+    }
+
+    function test_isAttackable_underAttack() public {
+        assertTrue(harness.exposedIsAttackable(address(0xAAA)));
+    }
+
+    function test_isAttackable_promotionRequested() public {
+        assertTrue(harness.exposedIsAttackable(address(0xCCC)));
+    }
+
+    function test_isAttackable_notAttackable() public {
+        assertFalse(harness.exposedIsAttackable(address(0xBBB)));
+    }
+
+    function test_isAttackable_noCoverage() public {
+        assertFalse(harness.exposedIsAttackable(address(0xEEE)));
+    }
+
+    function test_isAttackable_revertsOnApiError() public {
+        vm.expectRevert();
+        harness.exposedIsAttackable(address(0xDDD));
+    }
+}

--- a/test/mocks/mock_api.sh
+++ b/test/mocks/mock_api.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# mock_api.sh - returns mock block explorer API responses for BCQuery tests
+# Usage: mock_api.sh <address>
+
+ADDR=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+# Agreement in UNDER_ATTACK state — isAttackable: true
+if [ "$ADDR" = "0x0000000000000000000000000000000000000aaa" ]; then
+    printf '{"agreements":[{"state":"UNDER_ATTACK"}],"hasCoverage":true,"isAgreementContract":false}'
+# Agreement in PRODUCTION state — hasCoverage but not attackable
+elif [ "$ADDR" = "0x0000000000000000000000000000000000000bbb" ]; then
+    printf '{"agreements":[{"state":"PRODUCTION"}],"hasCoverage":true,"isAgreementContract":false}'
+# Agreement in PROMOTION_REQUESTED state — isAttackable: true
+elif [ "$ADDR" = "0x0000000000000000000000000000000000000ccc" ]; then
+    printf '{"agreements":[{"state":"PROMOTION_REQUESTED"}],"hasCoverage":true,"isAgreementContract":false}'
+# No coverage at all
+elif [ "$ADDR" = "0x0000000000000000000000000000000000000eee" ]; then
+    printf '{"agreements":[],"hasCoverage":false,"isAgreementContract":false}'
+else
+    # Simulate API error (empty output)
+    exit 1
+fi


### PR DESCRIPTION
- Add BCQuery contract that checks whether a contract is covered by a Safe Harbor agreement in attackable mode (UNDER_ATTACK or PROMOTION_REQUESTED) by querying the block explorer API via vm.ffi.
- remove incorrect instruction about EIP-1559 incompatibility from SKILL.md