### PR TITLE
fix: correct mainnet block explorer API URL

### DIFF
--- a/src/BCQuery.sol
+++ b/src/BCQuery.sol
@@ -13,7 +13,7 @@ abstract contract BCQuery is BCBase {
     // -------------------------------------------------------------------------
 
     string internal constant TESTNET_EXPLORER_API = "https://block-explorer-api.testnet.battlechain.com";
-    string internal constant MAINNET_EXPLORER_API = "https://block-explorer-api.battlechain.com";
+    string internal constant MAINNET_EXPLORER_API = "https://block-explorer-api.mainnet.battlechain.com";
 
     // -------------------------------------------------------------------------
     // Errors


### PR DESCRIPTION
**What**
Corrects MAINNET_EXPLORER_API to https://block-explorer-api.mainnet.battlechain.com.

**Why**
The previous value (block-explorer-api.battlechain.com) 308-redirects to the mainnet. subdomain. _queryAgreementByContract uses curl -sf, which does not follow redirects, so all mainnet isAttackable queries received the redirect HTML and reverted on JSON parse. The testnet constant already uses the testnet. subdomain pattern; this aligns mainnet with it.

**Testing**
Verified end-to-end against mainnet (chainid 626): isAttackable returns true for a contract with an UNDER_ATTACK agreement. Existing 5 BCQueryTest unit tests (mock-based) still pass.