### PR TITLE
ci: publish npm packages via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -27,12 +27,13 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships npm 10.x.
+      - run: npm install -g npm@latest
+
       - run: npm ci
 
       - run: npm run build
 
       - run: npm pkg set version="${GITHUB_REF_NAME#js-v}"
 
-      - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,8 +6,11 @@ on:
     tags:
       - 'v*'
 
+# OIDC trusted publishing (no NPM_TOKEN). Requires a trusted publisher configured
+# on npmjs.com (org Cyfrin, repo battlechain-lib, workflow publish-npm.yml).
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -22,8 +25,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships npm 10.x.
+      - run: npm install -g npm@latest
+
       - run: npm pkg set version="${GITHUB_REF_NAME#v}"
 
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Switch npm publishing from a stored NPM_TOKEN to OIDC trusted publishing.