### PR TITLE
docs: refresh py CONTRIBUTING for generated modules; add RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,76 @@
+# Releasing
+
+This monorepo publishes three packages, each from its own git tag, via **OIDC
+trusted publishing** — there are no long-lived npm/PyPI tokens stored anywhere.
+
+| Package | Source | Registry | Tag | Workflow |
+| --- | --- | --- | --- | --- |
+| `@cyfrin/battlechain-lib` | Solidity at the root + `deployments.json` + `abis/` | npm | `v*` | `publish-npm.yml` |
+| `@cyfrin/battlechain-lib-js` | `packages/battlechain-lib-js` (ethers SDK) | npm | `js-v*` | `publish-js.yml` |
+| `battlechain-lib-py` | `packages/battlechain-lib-py` | PyPI | `py-v*` | `publish-pypi.yml` |
+
+The **tag prefix** selects which workflow runs; each workflow builds and
+publishes only its own package directory. All three tags point at the same
+commit, but they publish independently.
+
+## One-time setup (per package, already done for the current packages)
+
+Publishing authenticates via GitHub Actions OIDC, so each package needs a
+**Trusted Publisher** configured on its registry — no token secrets.
+
+- **npm** — npmjs.com → the package → Settings → Trusted Publisher → GitHub
+  Actions:
+  - Organization: `Cyfrin` *(case-sensitive — must match the GitHub URL exactly)*
+  - Repository: `battlechain-lib`
+  - Workflow filename: `publish-npm.yml` or `publish-js.yml` *(filename only, not the path)*
+  - Environment: leave blank
+  - Allowed action: `npm publish`
+  - Publishing access: "require two-factor authentication and disallow tokens"
+    (recommended — OIDC is unaffected by it)
+- **PyPI** — the project → trusted publishers → GitHub: repo `Cyfrin/battlechain-lib`,
+  workflow `publish-pypi.yml`, environment `production`.
+
+> **New npm packages:** npm cannot configure a Trusted Publisher for a package
+> that doesn't exist yet. The *first* publish of a brand-new npm package must be
+> done once with a short-lived token or a local `npm publish`; configure the
+> Trusted Publisher afterward and all later versions go through OIDC. (PyPI has
+> "pending publishers", so this caveat is npm-only.)
+
+## Cutting a release
+
+1. **Bump the version** in the package's manifest and add a `CHANGELOG.md` entry:
+   - canonical → root `package.json`
+   - js → `packages/battlechain-lib-js/package.json`
+   - py → `packages/battlechain-lib-py/pyproject.toml` (then `uv lock`)
+2. **If the contracts changed, regenerate** (CI's `codegen-check` enforces this):
+   ```bash
+   forge build && node scripts/codegen.mjs        # canonical: deployments.json + abis/
+   (cd packages/battlechain-lib-js && npm run gen)
+   (cd packages/battlechain-lib-py && just gen)
+   ```
+3. **Open a PR, review, merge to `main`.**
+4. **Tag the merged `main` and push** — the matching workflow publishes:
+   ```bash
+   git checkout main && git pull
+   git tag v1.1.0    && git push origin v1.1.0      # @cyfrin/battlechain-lib
+   git tag js-v1.1.0 && git push origin js-v1.1.0   # @cyfrin/battlechain-lib-js
+   git tag py-v1.1.0 && git push origin py-v1.1.0   # battlechain-lib-py
+   ```
+   Push **tags** — they are the trigger. GitHub Releases are optional (notes only).
+   Watch the runs in the Actions tab.
+5. **Bump downstream consumers** after the publish lands: the docs site's
+   `@cyfrin/battlechain-lib` dependency, and moccasin's `battlechain-lib-py`.
+
+## Gotchas
+
+- **`repository.url` casing must match the GitHub org exactly** (`Cyfrin`, not
+  `cyfrin`). npm provenance verification rejects a mismatch with `E422` *after*
+  building and signing — so the run looks like it worked until the final PUT.
+- **npm ≥ 11.5.1 is required for OIDC.** Node 22 ships npm 10.x, so the publish
+  workflows run `npm install -g npm@latest` first.
+- **Dependency cooldown.** `min-release-age=7` (npm) / `exclude-newer = "7 days"`
+  (uv) block installing a version published in the last 7 days. To consume a
+  just-published first-party package immediately (e.g. regenerating a downstream
+  lockfile), bypass it once: `npm install --min-release-age=0`.
+- **Versions are independent.** A package may skip a number on a registry (e.g.
+  publishing canonical `1.1.0` when `1.0.0` never landed) — that's fine.

--- a/packages/battlechain-lib-py/CONTRIBUTING.md
+++ b/packages/battlechain-lib-py/CONTRIBUTING.md
@@ -103,52 +103,48 @@ uvx ty check
 
 We use [`ty`](https://github.com/astral-sh/ty), Astral's static type checker.
 
-### Regenerate the ABI module
+### Regenerate the generated modules
 
-`battlechain/abi.py` is auto-generated from forge build artifacts in the
-sibling `battlechain-lib` Solidity repo. Whenever the Solidity interfaces
-change, regenerate:
+`battlechain/abi.py` and `battlechain/_contract_data.py` are **generated — do not
+hand-edit them.** They derive from the committed artifacts the canonical
+`@cyfrin/battlechain-lib` monorepo produces at its root (this package lives at
+`packages/battlechain-lib-py/`):
+
+- `abi.py` ← `../../abis/*.json` (raw contract ABIs)
+- `_contract_data.py` ← `../../deployments.json` (addresses, chain IDs, CAIP-2
+  ids, Safe Harbor URIs, CreateX chain lists)
+
+Those root artifacts are themselves generated from the deployed Solidity in
+[`battlechain-safe-harbor-contracts`](https://github.com/Cyfrin/battlechain-safe-harbor-contracts)
+(the source of truth) by the monorepo's `scripts/codegen.mjs`. Regenerate the
+Python side with:
 
 ```bash
-# Defaults to ../battlechain-lib
-uv run python tools/gen_abi.py
-
-# Or point at a specific working copy
-uv run python tools/gen_abi.py /path/to/battlechain-lib
-
-# Skip `forge build` if you've already built (faster iteration)
-uv run python tools/gen_abi.py --no-build
+just gen          # = gen-abi + gen-config
+# or individually:
+uv run python tools/gen_abi.py        # rewrites battlechain/abi.py from ../../abis
+uv run python tools/gen_config.py     # rewrites battlechain/_contract_data.py from ../../deployments.json
 ```
 
-The script:
-1. Runs `forge build` inside the Solidity repo (unless `--no-build`).
-2. Reads `out/<Iface>.sol/<Iface>.json` for each interface (`IAgreementFactory`,
-   `IAgreement`, `IAttackRegistry`, `IBCSafeHarborRegistry`, `IBCDeployer`).
-3. Extracts the `.abi` field from each artifact.
-4. Renders `battlechain/abi.py` with the standard ABI list-of-dicts shape that
-   boa and web3.py both accept.
+Commit the regenerated files alongside the change that motivated them. A
+`codegen-check` CI job re-runs every generator and fails on any drift, so the
+committed output can't silently fall out of sync.
 
-Commit the regenerated `abi.py` alongside any code changes that motivated it.
+## Keeping in sync with the contracts
 
-## Keeping in sync with battlechain-lib (Solidity)
+Addresses and ABIs are **generated**, so most "syncing" is automatic. The chain
+of truth is: `battlechain-safe-harbor-contracts` (deployed contracts) →
+`scripts/codegen.mjs` → `deployments.json` + `abis/` → this package's generators.
 
-This library mirrors the public surface of
-[`cyfrin/battlechain-lib`](https://github.com/Cyfrin/battlechain-lib). When the
-Solidity lib changes, here's what to update:
+| What changed | What to do here |
+| --- | --- |
+| Contract addresses / chain IDs / URIs | nothing by hand — `just gen` regenerates `battlechain/_contract_data.py` from `../../deployments.json` |
+| Interface ABIs | nothing by hand — `just gen` regenerates `battlechain/abi.py` from `../../abis/` |
+| Behavior of a builder / action / query | edit the hand-written logic: `config.py`, `createx_chains.py`, `types.py`, `builders.py`, `safe_harbor.py`, `query.py`, `deploy.py`, `errors.py` |
 
-| Solidity change              | Python update                                                         |
-| ---------------------------- | --------------------------------------------------------------------- |
-| `BCConfig.sol` addresses     | `battlechain/config.py` constants + `bc_mainnet` / `bc_testnet`       |
-| `AgreementTypes.sol`         | `battlechain/types.py` dataclasses/enums                              |
-| Interface methods            | Run `tools/gen_abi.py` to refresh `battlechain/abi.py`                |
-| `BCSafeHarbor.sol` builders  | `battlechain/builders.py` + corresponding `safe_harbor.py` actions    |
-| `BCDeploy.sol` helpers       | `battlechain/deploy.py`                                               |
-| `BCQuery.sol` predicates     | `battlechain/query.py` (Python uses HTTP directly instead of FFI)     |
-| `CreateXChains.sol` chain list | `battlechain/createx_chains.py` `PRODUCTION_CHAIN_IDS` / `TEST_CHAIN_IDS` |
-| New custom errors            | `battlechain/errors.py`                                               |
-
-Add a test in `tests/test_smoke.py` that pins the new behavior to a value from
-the Solidity source — that's the cheapest way to catch silent drift.
+Run `just gen` and commit the regenerated files. Add a test in
+`tests/test_smoke.py` that pins the new behavior to a value from the canonical
+artifacts — the cheapest way to catch silent drift.
 
 ## Conventions
 


### PR DESCRIPTION
CONTRIBUTING.md (py): the old text described gen_abi running forge build / reading out/<Iface>.sol and a hand-maintained sync model — obsolete since the monorepo move. Rewritten to reflect that abi.py + _contract_data.py are generated from the root ../../abis + ../../deployments.json (themselves generated from the battlechain-safe-harbor-contracts submodule), regenerated via just gen, and guarded by codegen-check.

RELEASING.md (new, monorepo root): documents the per-package tag-driven OIDC release flow (v*/js-v*/py-v*), one-time trusted-publisher setup, the new-npm-package bootstrap caveat, and gotchas (repository.url casing/E422, npm>=11.5.1, the dependency cooldown bypass).