### PR TITLE
fix(py): approve_attack_request + vyper verify version & query-ABI duplication

### DIFF
--- a/packages/battlechain-lib-py/battlechain/__init__.py
+++ b/packages/battlechain-lib-py/battlechain/__init__.py
@@ -83,6 +83,7 @@ from battlechain.query import (
 )
 from battlechain.safe_harbor import (
     adopt_agreement,
+    approve_attack_request,
     create_agreement,
     create_and_adopt_agreement,
     request_attack_mode,
@@ -168,6 +169,7 @@ __all__ = [
     "track_deployment",
     # safe harbor
     "adopt_agreement",
+    "approve_attack_request",
     "create_agreement",
     "create_and_adopt_agreement",
     "request_attack_mode",

--- a/packages/battlechain-lib-py/battlechain/_boa.py
+++ b/packages/battlechain-lib-py/battlechain/_boa.py
@@ -17,6 +17,7 @@ from battlechain.abi import (
     AGREEMENT_FACTORY_ABI,
     ATTACK_REGISTRY_ABI,
     DEPLOYER_ABI,
+    MOCK_REGISTRY_MODERATOR_ABI,
     REGISTRY_ABI,
 )
 
@@ -77,3 +78,12 @@ def deployer(address: str | None = None) -> Any:
     """
     addr = address or config.deployer_address(chain_id())
     return _load(DEPLOYER_ABI, addr, name="BCDeployer")
+
+
+def mock_registry_moderator(address: str | None = None) -> Any:
+    """Load the permissionless MockRegistryModerator for the active chain.
+
+    Only deployed on BattleChain testnet (self-approval of attack requests).
+    """
+    addr = address or config.mock_registry_moderator_address(chain_id())
+    return _load(MOCK_REGISTRY_MODERATOR_ABI, addr, name="MockRegistryModerator")

--- a/packages/battlechain-lib-py/battlechain/abi.py
+++ b/packages/battlechain-lib-py/battlechain/abi.py
@@ -1048,6 +1048,17 @@ DEPLOYER_ABI: list[dict[str, Any]] = [
     },
 ]
 
+# Source: abis/registryModerator.json
+MOCK_REGISTRY_MODERATOR_ABI: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "name": "approveAttack",
+        "inputs": [{"name": "agreementAddress", "type": "address", "internalType": "address"}],
+        "outputs": [],
+        "stateMutability": "nonpayable",
+    }
+]
+
 
 __all__ = [
     "AGREEMENT_FACTORY_ABI",
@@ -1055,4 +1066,5 @@ __all__ = [
     "ATTACK_REGISTRY_ABI",
     "REGISTRY_ABI",
     "DEPLOYER_ABI",
+    "MOCK_REGISTRY_MODERATOR_ABI",
 ]

--- a/packages/battlechain-lib-py/battlechain/config.py
+++ b/packages/battlechain-lib-py/battlechain/config.py
@@ -223,6 +223,19 @@ def attack_registry_address(chain_id: int) -> str:
     return get_network_config(chain_id).attack_registry
 
 
+def mock_registry_moderator_address(chain_id: int) -> str | None:
+    """Return the permissionless MockRegistryModerator address for a chain.
+
+    Only deployed on BattleChain testnet, where it lets an adopter self-approve
+    a pending attack request (ATTACK_REQUESTED -> UNDER_ATTACK). Returns None on
+    any other chain — on mainnet, approval is a real DAO governance action.
+    Mirrors JS `mockRegistryModeratorAddress`.
+    """
+    if chain_id == TESTNET_CHAIN_ID:
+        return TESTNET_MOCK_REGISTRY_MODERATOR
+    return None
+
+
 def deployer_address(chain_id: int) -> str:
     """Return the deployer address for a chain.
 
@@ -332,6 +345,7 @@ __all__ = [
     "explorer_host",
     "get_network_config",
     "is_battlechain",
+    "mock_registry_moderator_address",
     "registry_address",
     "safe_harbor_uri",
     "set_overrides",

--- a/packages/battlechain-lib-py/battlechain/query.py
+++ b/packages/battlechain-lib-py/battlechain/query.py
@@ -98,33 +98,12 @@ def is_attackable(contract_address: str) -> bool:
 # These work only for *top-level* contracts (those deployed via
 # BattleChainDeployer). For child contracts, prefer `is_attackable` above.
 
-_ATTACK_REGISTRY_QUERY_METHODS: list[dict[str, Any]] = [
-    {
-        "type": "function",
-        "name": "getAgreementState",
-        "stateMutability": "view",
-        "inputs": [{"name": "agreementAddress", "type": "address"}],
-        "outputs": [{"name": "", "type": "uint8"}],
-    },
-    {
-        "type": "function",
-        "name": "getAgreementForContract",
-        "stateMutability": "view",
-        "inputs": [{"name": "contractAddress", "type": "address"}],
-        "outputs": [{"name": "", "type": "address"}],
-    },
-    {
-        "type": "function",
-        "name": "isTopLevelContractUnderAttack",
-        "stateMutability": "view",
-        "inputs": [{"name": "contractAddress", "type": "address"}],
-        "outputs": [{"name": "", "type": "bool"}],
-    },
-]
-
-ATTACK_REGISTRY_QUERY_ABI: list[dict[str, Any]] = (
-    ATTACK_REGISTRY_ABI + _ATTACK_REGISTRY_QUERY_METHODS
-)
+# The generated ATTACK_REGISTRY_ABI already includes the read methods
+# (getAgreementState, getAgreementForContract, isTopLevelContractUnderAttack), so
+# this is just an alias. It used to concatenate hand-written copies of those three
+# methods, which — once the ABI was regenerated to include them — produced duplicate
+# entries and made boa raise "Ambiguous call to getAgreementState".
+ATTACK_REGISTRY_QUERY_ABI: list[dict[str, Any]] = ATTACK_REGISTRY_ABI
 
 
 def _query_registry() -> Any:

--- a/packages/battlechain-lib-py/battlechain/safe_harbor.py
+++ b/packages/battlechain-lib-py/battlechain/safe_harbor.py
@@ -9,7 +9,7 @@ import time
 
 from battlechain import _boa, config
 from battlechain.builders import DEFAULT_COMMITMENT_DAYS
-from battlechain.errors import NotBattleChainError
+from battlechain.errors import BattleChainError, NotBattleChainError
 from battlechain.types import AgreementDetails
 
 SECONDS_PER_DAY = 24 * 60 * 60
@@ -77,6 +77,26 @@ def request_attack_mode(agreement_address: str) -> None:
     _boa.attack_registry().requestUnderAttack(agreement_address)
 
 
+def approve_attack_request(agreement_address: str) -> None:
+    """Self-approve a pending attack request via the testnet MockRegistryModerator.
+
+    Moves the agreement from ATTACK_REQUESTED (2) to UNDER_ATTACK (3). Mirrors JS
+    `approveAttackRequest` and the `cast send <moderator> "approveAttack(address)"`
+    flow from the BattleChain testnet docs. Only available on testnet, where the
+    moderator is permissionless; on mainnet, approval is a real DAO governance
+    action, so this raises.
+    """
+    chain_id = _boa.chain_id()
+    moderator = config.mock_registry_moderator_address(chain_id)
+    if moderator is None:
+        raise BattleChainError(
+            f"approve_attack_request is only available on BattleChain testnet "
+            f"(chain ID {config.TESTNET_CHAIN_ID}); got chain ID {chain_id}. "
+            f"On mainnet, approval is a real DAO governance action."
+        )
+    _boa.mock_registry_moderator(moderator).approveAttack(agreement_address)
+
+
 def skip_to_production(agreement_address: str) -> None:
     """Skip an agreement directly to production. Only available on BattleChain.
 
@@ -90,6 +110,7 @@ def skip_to_production(agreement_address: str) -> None:
 
 __all__ = [
     "adopt_agreement",
+    "approve_attack_request",
     "create_agreement",
     "create_and_adopt_agreement",
     "request_attack_mode",

--- a/packages/battlechain-lib-py/battlechain/verify.py
+++ b/packages/battlechain-lib-py/battlechain/verify.py
@@ -108,6 +108,37 @@ def _build_vyper_payload(contract_file: str, source_code: str) -> dict[str, Any]
     }
 
 
+_VYPER_RELEASES_URL = "https://vyper-releases-mirror.hardhat.org/list.json"
+
+
+def _resolve_vyper_version(version: str) -> str:
+    """Resolve a vyper version to the full ``X.Y.Z+commit.<hash>`` form.
+
+    The explorer's verifier (Sourcify) fetches the compiler binary by version and
+    needs the full version *with* commit hash and *no* leading "v" — a bare
+    "0.4.3" 404s ("Failed fetching vyper 0.4.3 for platform linux"). `vyper`
+    doesn't expose its commit hash at runtime, so derive it from the same release
+    list the explorer UI uses. Already-full versions pass through (sans leading "v");
+    on any lookup failure we fall back to the bare version rather than block.
+    """
+    v = version.lstrip("v")
+    if "+commit." in v:
+        return v
+    try:
+        with urllib.request.urlopen(_VYPER_RELEASES_URL, timeout=15) as resp:
+            releases = json.loads(resp.read())
+        for release in releases:
+            for asset in release.get("assets", []):
+                name = asset.get("name", "")  # e.g. "vyper.0.4.3+commit.bff19ea2.linux"
+                if name.startswith("vyper.") and name.endswith(".linux"):
+                    full = name[len("vyper.") : -len(".linux")]
+                    if full.split("+commit.")[0] == v:
+                        return full
+    except Exception as exc:  # noqa: BLE001 - network/parse failure is non-fatal
+        print(f"  ⚠ Could not resolve full vyper version for {v}: {exc}")
+    return v
+
+
 def verify_contract(
     address: str,
     contract_fqn: str,
@@ -123,8 +154,9 @@ def verify_contract(
     Args:
         address: Deployed contract address.
         contract_fqn: File path and contract name, e.g. "src/MockToken.vy:MockToken".
-        compiler_version: Compiler version string (e.g. "0.4.0" — the leading
-            "v" is added automatically).
+        compiler_version: Compiler version string (e.g. "0.4.3"). Resolved to the
+            full "X.Y.Z+commit.<hash>" form the verifier needs; full versions and
+            a leading "v" are also accepted.
         source_path: Override path to the source file. Defaults to the path
             component of `contract_fqn`.
         chain_id: Override chain ID. Defaults to the active boa environment.
@@ -165,7 +197,7 @@ def verify_contract(
             "sourceCode": json.dumps(std_json),
             "codeformat": code_format,
             "contractname": contract_fqn,
-            "compilerversion": f"v{compiler_version}",
+            "compilerversion": _resolve_vyper_version(compiler_version),
         })
     except urllib.error.URLError as exc:
         print(f"  ✗ Verification submission failed: {exc}")

--- a/packages/battlechain-lib-py/tools/gen_abi.py
+++ b/packages/battlechain-lib-py/tools/gen_abi.py
@@ -29,6 +29,7 @@ ARTIFACTS = {
     "attackRegistry": "ATTACK_REGISTRY_ABI",
     "registry": "REGISTRY_ABI",
     "deployer": "DEPLOYER_ABI",
+    "registryModerator": "MOCK_REGISTRY_MODERATOR_ABI",
 }
 
 # Package root is two levels up from this file (tools/ -> battlechain-lib-py/).


### PR DESCRIPTION
Three `battlechain-lib-py` correctness fixes, all found and **verified live on testnet** while exercising the `vyper-template` flow end-to-end.

## 1. `approve_attack_request` (new) — Python↔JS parity
JS exposes `approveAttackRequest`; Python had no equivalent, so the vyper-template flow could never reach `UNDER_ATTACK`. Adds:
- `safe_harbor.approve_attack_request(agreement)` — self-approves via the permissionless testnet `MockRegistryModerator` (`ATTACK_REQUESTED → UNDER_ATTACK`); raises on non-testnet (mainnet approval is real DAO governance).
- `config.mock_registry_moderator_address()` resolver + a `_boa` loader.
- **Root cause of the missing ABI:** `tools/gen_abi.py`'s `ARTIFACTS` map omitted `registryModerator`, so `MOCK_REGISTRY_MODERATOR_ABI` was never generated. Added the mapping and regenerated.

Verified live: `approve_attack_request` moved a real agreement to `UNDER_ATTACK (3)`.

## 2. `verify_contract` sent a malformed vyper version
It submitted `v0.4.3` — a bare version with a spurious `v`. The explorer's Sourcify verifier fetches the compiler by version and needs the full `0.4.3+commit.<hash>` with **no** leading `v`; a bare version 404s:
```
✗ Verification failed: Compiler error. Failed fetching vyper 0.4.3 for platform linux.
```
Since the lib only supports `vyper-json`, **Vyper verification never worked.** Added `_resolve_vyper_version()` to derive the full `X.Y.Z+commit.<hash>` from the vyper releases mirror (same source the explorer UI uses; `vyper` doesn't expose its commit hash at runtime). Falls back gracefully on lookup failure.

Verified live: MockToken `0x1ce3…332E` → `✅ Verified`.

## 3. `ATTACK_REGISTRY_QUERY_ABI` produced duplicate entries
It concatenated hand-written copies of `getAgreementState` / `getAgreementForContract` / `isTopLevelContractUnderAttack` onto `ATTACK_REGISTRY_ABI` — which (since the ABI was regenerated to include the read methods) already contains them. boa then raised `Ambiguous call to getAgreementState`, breaking all three on-chain query helpers + `check_state`. Now a plain alias of `ATTACK_REGISTRY_ABI`.

Verified live: `check_state` returns `UNDER_ATTACK (3)`.

ruff clean; 33/33 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)